### PR TITLE
Parameterize simple simulation problem size and agent count

### DIFF
--- a/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation.py
+++ b/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation.py
@@ -50,6 +50,7 @@ class CBMPopulationAgentOnlineSimpleSimulation(Node):
                  positive_reward=1,
                  negative_reward=-0.5,
                  num_tsp_agents=10,
+                 problem_size=15,
                  lock_mode: bool = False,
                  preserve_next_task = False,
                  use_ucb: bool = False,
@@ -87,6 +88,7 @@ class CBMPopulationAgentOnlineSimpleSimulation(Node):
                       - Exploration c:   {ucb_c}
 
                     Number of TSP Agents: {num_tsp_agents}
+                    Problem Size:         {problem_size}
                     =======================================================
                     """
         print(settings_str)
@@ -100,12 +102,8 @@ class CBMPopulationAgentOnlineSimpleSimulation(Node):
         self.current_task = None
         self.current_tasks = [-1] * num_tsp_agents
 
-        self.problem = SimpleProblem(ProblemClass.SimpleGrid)
-
-        """
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(15) for j in range(15)]
-        self.num_tasks = len(self.task_poses)
-        """
+        self.problem = SimpleProblem(ProblemClass.SimpleGrid, grid_size=problem_size)
+        self.problem_size = self.problem.grid_size
 
         self.lock_mode = lock_mode
         self.preserve_next_task = preserve_next_task
@@ -1656,6 +1654,7 @@ def main(args=None):
         "positive_reward": 1.0,
         "negative_reward": -0.5,
         "num_tsp_agents": 10,
+        "problem_size": 15,
         "lock_mode": False,
         "preserve_next_task": False,
         # NEW PARAMETERS
@@ -1676,6 +1675,7 @@ def main(args=None):
     positive_reward = temp_node.get_parameter("positive_reward").value
     negative_reward = temp_node.get_parameter("negative_reward").value
     num_tsp_agents  = temp_node.get_parameter("num_tsp_agents").value
+    problem_size    = temp_node.get_parameter("problem_size").value
     lock_mode       = temp_node.get_parameter("lock_mode").value
     preserve_next_task = temp_node.get_parameter("preserve_next_task").value
     eta             = temp_node.get_parameter("eta").value
@@ -1692,7 +1692,7 @@ def main(args=None):
         num_tsp_agents=num_tsp_agents, lr=lr,
         gamma_decay=gamma_decay, positive_reward=positive_reward,
         negative_reward=negative_reward, lock_mode=lock_mode, preserve_next_task=preserve_next_task,
-        use_ucb=use_ucb, ucb_c=ucb_c
+        use_ucb=use_ucb, ucb_c=ucb_c, problem_size=problem_size
     )
     print("CBMPopulationAgentOnlineSimpleSimulation has been initialized.")
 

--- a/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_lock.py
+++ b/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_lock.py
@@ -45,7 +45,8 @@ class CBMPopulationAgentOnlineSimpleSimulationLock(Node):
                  gamma_decay = 0.99,
                  positive_reward = 1.0,
                  negative_reward = -0.5,
-                 num_tsp_agents = 10):
+                 num_tsp_agents = 10,
+                 problem_size: int = 15):
 
         """
         Initialises the agent on startup
@@ -54,7 +55,15 @@ class CBMPopulationAgentOnlineSimpleSimulationLock(Node):
 
         print(f"Intiialising agent with parameters: lr {lr}, gamma_decay {gamma_decay}, positive reward {positive_reward}, negative reward: {negative_reward}")
 
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(15) for j in range(15)]
+        self.problem_size = int(problem_size)
+        if self.problem_size < 1:
+            raise ValueError("problem_size must be >= 1")
+
+        self.task_poses = [
+            (i + 0.5, j + 0.5)
+            for i in range(self.problem_size)
+            for j in range(self.problem_size)
+        ]
         self.num_tasks = len(self.task_poses)
         self.is_generating = False
         self.pop_size = pop_size
@@ -1371,6 +1380,7 @@ def main(args=None):
     temp_node.declare_parameter("positive_reward", 1.0)
     temp_node.declare_parameter("negative_reward", -0.5)
     temp_node.declare_parameter("num_tsp_agents", 10)
+    temp_node.declare_parameter("problem_size", 15)
 
     agent_id = temp_node.get_parameter("agent_id").value
     runtime = temp_node.get_parameter("runtime").value
@@ -1381,6 +1391,7 @@ def main(args=None):
     positive_reward = temp_node.get_parameter("positive_reward").value
     negative_reward = temp_node.get_parameter("negative_reward").value
     num_tsp_agents = temp_node.get_parameter("num_tsp_agents").value
+    problem_size = temp_node.get_parameter("problem_size").value
 
     temp_node.destroy_node()
 
@@ -1389,7 +1400,8 @@ def main(args=None):
         pop_size=10, eta=0.1, rho=0.1, di_cycle_length=5, epsilon=0.01,
         num_iterations=9999999, num_solution_attempts=21, agent_id=agent_id,
         node_name=node_name, learning_method=learning_method, num_tsp_agents=num_tsp_agents, lr=lr,
-        gamma_decay=gamma_decay, positive_reward=positive_reward, negative_reward=negative_reward
+        gamma_decay=gamma_decay, positive_reward=positive_reward, negative_reward=negative_reward,
+        problem_size=problem_size
     )
     print("CBMPopulationAgentOnlineSimpleSimulation has been initialized.")
 

--- a/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_nash.py
+++ b/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_nash.py
@@ -41,14 +41,23 @@ class CBMPopulationAgentOnlineSimpleSimulationNash(Node):
                  gamma_decay=0.99,
                  positive_reward=1.0,
                  negative_reward=-0.5,
-                 num_tsp_agents=10):
+                 num_tsp_agents=10,
+                 problem_size: int = 10):
 
         """
         Initialises the agent on startup
         """
         super().__init__(node_name)
 
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(10) for j in range(10)]
+        self.problem_size = int(problem_size)
+        if self.problem_size < 1:
+            raise ValueError("problem_size must be >= 1")
+
+        self.task_poses = [
+            (i + 0.5, j + 0.5)
+            for i in range(self.problem_size)
+            for j in range(self.problem_size)
+        ]
         self.num_tasks = len(self.task_poses)
         self.is_generating = False
         self.pop_size = pop_size
@@ -1426,18 +1435,21 @@ def main(args=None):
     temp_node.declare_parameter("runtime", -1.0)
     temp_node.declare_parameter("learning_method", "Ferreira et al.")
     temp_node.declare_parameter("num_tsp_agents", 5)
+    temp_node.declare_parameter("problem_size", 10)
 
     agent_id = temp_node.get_parameter("agent_id").value
     runtime = temp_node.get_parameter("runtime").value
     learning_method = temp_node.get_parameter("learning_method").value
     num_tsp_agents = temp_node.get_parameter("num_tsp_agents").value
+    problem_size = temp_node.get_parameter("problem_size").value
     temp_node.destroy_node()
 
     node_name = f"cbm_population_agent_{agent_id}"
     agent = CBMPopulationAgentOnlineSimpleSimulationNash(
         pop_size=10, eta=0.1, rho=0.1, di_cycle_length=5, epsilon=0.01,
         num_iterations=9999999, num_solution_attempts=21, agent_id=agent_id,
-        node_name=node_name, learning_method=learning_method, num_tsp_agents=num_tsp_agents
+        node_name=node_name, learning_method=learning_method, num_tsp_agents=num_tsp_agents,
+        problem_size=problem_size
     )
     print("CBMPopulationAgentOnlineSimpleSimulationNash has been initialized.")
 

--- a/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_offline.py
+++ b/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_offline.py
@@ -40,7 +40,8 @@ class CBMPopulationAgentOnlineSimpleSimulationOffline(Node):
                  gamma_decay = 0.99,
                  positive_reward = 1,
                  negative_reward = -0.5,
-                 num_tsp_agents = 10):
+                 num_tsp_agents = 10,
+                 problem_size: int = 10):
 
         """
         Initialises the agent on startup
@@ -69,11 +70,20 @@ class CBMPopulationAgentOnlineSimpleSimulationOffline(Node):
               - Negative Reward: {negative_reward}
 
             Number of TSP Agents: {num_tsp_agents}
+            Problem Size:         {problem_size}
             =======================================================
             """
         self.get_logger().info(settings_str)
         self.current_task = None
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(10) for j in range(10)]
+        self.problem_size = int(problem_size)
+        if self.problem_size < 1:
+            raise ValueError("problem_size must be >= 1")
+
+        self.task_poses = [
+            (i + 0.5, j + 0.5)
+            for i in range(self.problem_size)
+            for j in range(self.problem_size)
+        ]
 
         self.num_tasks = len(self.task_poses)
         self.is_generating = False
@@ -788,11 +798,13 @@ def main(args=None):
     temp_node.declare_parameter("runtime", -1.0)
     temp_node.declare_parameter("learning_method", "Ferreira_et_al.")
     temp_node.declare_parameter("num_tsp_agents", 5)
+    temp_node.declare_parameter("problem_size", 10)
 
     agent_id = temp_node.get_parameter("agent_id").value
     runtime = temp_node.get_parameter("runtime").value
     learning_method = temp_node.get_parameter("learning_method").value
     num_tsp_agents = temp_node.get_parameter("num_tsp_agents").value
+    problem_size = temp_node.get_parameter("problem_size").value
 
     temp_node.declare_parameter("lr", 0.5)
     temp_node.declare_parameter("gamma_decay", 0.99)
@@ -821,7 +833,8 @@ def main(args=None):
         gamma_decay=gamma_decay,
         positive_reward=positive_reward,
         negative_reward=negative_reward,
-        num_tsp_agents=num_tsp_agents
+        num_tsp_agents=num_tsp_agents,
+        problem_size=problem_size
     )
     print("CBMPopulationAgentOnlineSimpleSimulationOffline has been initialized.")
 

--- a/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_offline_UCB.py
+++ b/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_offline_UCB.py
@@ -67,7 +67,8 @@ class CBMPopulationAgentOnlineSimpleSimulationOfflineUCB(Node):
                  gamma_decay = 0.99,
                  positive_reward = 1,
                  negative_reward = 0,
-                 num_tsp_agents = 10):
+                 num_tsp_agents = 10,
+                 problem_size: int = 10):
 
         """
         Initialises the agent on startup
@@ -96,11 +97,20 @@ class CBMPopulationAgentOnlineSimpleSimulationOfflineUCB(Node):
               - Negative Reward: {negative_reward}
 
             Number of TSP Agents: {num_tsp_agents}
+            Problem Size:         {problem_size}
             =======================================================
             """
         self.get_logger().info(settings_str)
         self.current_task = None
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(10) for j in range(10)]
+        self.problem_size = int(problem_size)
+        if self.problem_size < 1:
+            raise ValueError("problem_size must be >= 1")
+
+        self.task_poses = [
+            (i + 0.5, j + 0.5)
+            for i in range(self.problem_size)
+            for j in range(self.problem_size)
+        ]
 
         self.num_tasks = len(self.task_poses)
         self.is_generating = False
@@ -874,11 +884,13 @@ def main(args=None):
     temp_node.declare_parameter("runtime", -1.0)
     temp_node.declare_parameter("learning_method", "Ferreira_et_al.")
     temp_node.declare_parameter("num_tsp_agents", 5)
+    temp_node.declare_parameter("problem_size", 10)
 
     agent_id = temp_node.get_parameter("agent_id").value
     runtime = temp_node.get_parameter("runtime").value
     learning_method = temp_node.get_parameter("learning_method").value
     num_tsp_agents = temp_node.get_parameter("num_tsp_agents").value
+    problem_size = temp_node.get_parameter("problem_size").value
 
     temp_node.declare_parameter("lr", 0.5)
     temp_node.declare_parameter("gamma_decay", 0.99)
@@ -907,7 +919,8 @@ def main(args=None):
         gamma_decay=gamma_decay,
         positive_reward=positive_reward,
         negative_reward=negative_reward,
-        num_tsp_agents=num_tsp_agents
+        num_tsp_agents=num_tsp_agents,
+        problem_size=problem_size
     )
     print("CBMPopulationAgentOnlineSimpleSimulationOffline has been initialized.")
 

--- a/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_reactive.py
+++ b/cbm_pop/SimpleSimulator/cbm_population_agent_online_simple_simulation_reactive.py
@@ -44,6 +44,7 @@ class CBMPopulationAgentOnlineSimpleSimulationReactive(Node):
                  positive_reward=1,
                  negative_reward=-0.5,
                  num_tsp_agents=10,
+                 problem_size: int = 15,
                  enable_chk_logs: bool = False):
 
         """
@@ -72,6 +73,7 @@ class CBMPopulationAgentOnlineSimpleSimulationReactive(Node):
                       - Negative Reward: {negative_reward}
 
                     Number of TSP Agents: {num_tsp_agents}
+                    Problem Size:         {problem_size}
                     =======================================================
                     """
 
@@ -83,7 +85,15 @@ class CBMPopulationAgentOnlineSimpleSimulationReactive(Node):
         })
 
         self.current_task = None
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(15) for j in range(15)]
+        self.problem_size = int(problem_size)
+        if self.problem_size < 1:
+            raise ValueError("problem_size must be >= 1")
+
+        self.task_poses = [
+            (i + 0.5, j + 0.5)
+            for i in range(self.problem_size)
+            for j in range(self.problem_size)
+        ]
         self.num_tasks = len(self.task_poses)
 
         # Core config
@@ -1792,6 +1802,7 @@ def main(args=None):
     temp_node.declare_parameter("positive_reward", 1.0)
     temp_node.declare_parameter("negative_reward", -0.5)
     temp_node.declare_parameter("num_tsp_agents", 10)
+    temp_node.declare_parameter("problem_size", 15)
 
     agent_id = temp_node.get_parameter("agent_id").value
     runtime = temp_node.get_parameter("runtime").value
@@ -1802,6 +1813,7 @@ def main(args=None):
     positive_reward = temp_node.get_parameter("positive_reward").value
     negative_reward = temp_node.get_parameter("negative_reward").value
     num_tsp_agents = temp_node.get_parameter("num_tsp_agents").value
+    problem_size = temp_node.get_parameter("problem_size").value
     temp_node.destroy_node()
 
     node_name = f"cbm_population_agent_{agent_id}"
@@ -1809,7 +1821,8 @@ def main(args=None):
         pop_size=10, eta=0.1, rho=0.1, di_cycle_length=10, epsilon=0.01,
         num_iterations=9999999, num_solution_attempts=21, agent_id=agent_id,
         node_name=node_name, learning_method=learning_method, num_tsp_agents=num_tsp_agents, lr=lr,
-        gamma_decay=gamma_decay, positive_reward=positive_reward, negative_reward=negative_reward
+        gamma_decay=gamma_decay, positive_reward=positive_reward, negative_reward=negative_reward,
+        problem_size=problem_size
     )
     print("CBMPopulationAgentOnlineSimpleSimulation has been initialized.")
 

--- a/cbm_pop/SimpleSimulator/simple_fitness_logger.py
+++ b/cbm_pop/SimpleSimulator/simple_fitness_logger.py
@@ -55,7 +55,12 @@ class SimpleFitnessLogger(Node):
 
         # Allow overriding agents if you want (otherwise auto-detect from first Solution)
         self.declare_parameter('num_tsp_agents', 10)
+        self.declare_parameter('problem_size', 15)
         self.num_tsp_agents = self.get_parameter('num_tsp_agents').get_parameter_value().integer_value
+        self.problem_size = self.get_parameter('problem_size').get_parameter_value().integer_value
+
+        if self.problem_size < 1:
+            raise ValueError("problem_size must be >= 1")
 
         # Output root
         self.declare_parameter('parent_log_dir', 'resources/run_logs')
@@ -91,8 +96,12 @@ class SimpleFitnessLogger(Node):
         with open(self.debug_log_file, mode="w") as f:
             f.write("Debug log for simple_fitness_logger\n")
 
-        # World/task info (10x10 grid at cell centers)
-        self.task_poses = [(i + 0.5, j + 0.5) for i in range(15) for j in range(15)]
+        # World/task info (square grid at cell centers)
+        self.task_poses = [
+            (i + 0.5, j + 0.5)
+            for i in range(self.problem_size)
+            for j in range(self.problem_size)
+        ]
         self.problem = ProblemAdapter()
         self.problem.cost_matrix = self.calculate_task_task_cost_matrix()
 

--- a/cbm_pop/SimpleSimulator/simple_problem.py
+++ b/cbm_pop/SimpleSimulator/simple_problem.py
@@ -9,12 +9,26 @@ class ProblemClass(Enum):
 
 
 class SimpleProblem:
-    def __init__(self, problem_class):
+    def __init__(self, problem_class, grid_size=15):
         self.task_poses = None
         self.initial_robot_cost_matrix = None
         self.current_robot_cost_matrix = None
+        self.problem_class = problem_class
+
+        try:
+            size = int(grid_size)
+        except (TypeError, ValueError):
+            raise ValueError("grid_size must be an integer") from None
+
+        if size < 1:
+            raise ValueError("grid_size must be >= 1")
+
+        self.grid_size = size
+
         if problem_class == ProblemClass.SimpleGrid:
-            self.task_poses = [(i + 0.5, j + 0.5) for i in range(15) for j in range(15)]
+            self.task_poses = [(i + 0.5, j + 0.5) for i in range(size) for j in range(size)]
+        else:
+            raise NotImplementedError(f"Unsupported problem class: {problem_class}")
         self.cost_matrix = self.calculate_cost_matrix()
         self.num_tasks = len(self.task_poses)
 

--- a/cbm_pop/SimpleSimulator/simple_simulator.py
+++ b/cbm_pop/SimpleSimulator/simple_simulator.py
@@ -208,13 +208,25 @@ def main():
     parser = argparse.ArgumentParser(description="Run CBM-POP Simulation")
     parser.add_argument('--num_robots', type=int, default=2, help='Number of robots')
     parser.add_argument('--speed', type=float, default=0.05, help='Robot speed')
-    parser.add_argument('--env_size', type=int, default=5, help='Environment size (square)')
+    parser.add_argument('--problem_size', type=int, default=None,
+                        help='Side length of the square grid (number of cells per side)')
+    parser.add_argument('--env_size', type=int, default=None, help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     rclpy.init(args=sys.argv)
 
-    tasks = [(i + 0.5, j + 0.5) for i in range(15) for j in range(15)]
-    env_bounds = [0, 15, 0, 15]
+    problem_size = args.problem_size if args.problem_size is not None else args.env_size
+    if problem_size is None:
+        problem_size = 15
+
+    problem_size = int(problem_size)
+    if problem_size < 1:
+        raise ValueError("problem_size must be >= 1")
+
+    args.problem_size = problem_size
+
+    tasks = [(i + 0.5, j + 0.5) for i in range(problem_size) for j in range(problem_size)]
+    env_bounds = [0, problem_size, 0, problem_size]
     xmin, xmax, ymin, ymax = env_bounds
 
     starts = [[(np.random.uniform(xmin, xmax), np.random.uniform(ymin, ymax))] for _ in range(args.num_robots)]


### PR DESCRIPTION
## Summary
- allow all simple simulation agents to accept a configurable problem size alongside their existing agent-count settings
- expose the problem size parameter through the simple simulator CLI and fitness logger
- update the simple problem helper to build task grids based on the requested dimensions

## Testing
- python -m compileall cbm_pop/SimpleSimulator

------
https://chatgpt.com/codex/tasks/task_e_68d2a5c3888083319d92519f0ae3f6f7